### PR TITLE
Fix: Removes sensitive fields from user obj reply

### DIFF
--- a/pet_sitter/basemodels.py
+++ b/pet_sitter/basemodels.py
@@ -102,3 +102,41 @@ class UpdatePetBody(BaseModel):
   profile_picture_src: str | None = None
   pet_bio_picture_src_list: str | None = None
   profile_bio: str | None = None
+
+class FullAppuserResponseObject(BaseModel):
+  id: int
+  firstname: str | None
+  lastname: str | None
+  email: str | None
+  profile_picture_src: str | None
+  prefecture: str | None
+  city_ward: str | None
+  street_address: str | None
+  postal_code: str | None
+  account_language: str | None
+  english_ok: bool | None
+  japanese_ok: bool | None
+  average_user_rating: float | None
+  user_profile_bio: str | None
+  user_bio_picture_src_list: str | None
+
+  class Config:
+    from_attributes = True
+
+class ReducedAppuserResponseObject(BaseModel):
+  id: int
+  firstname: str | None
+  lastname: str | None
+  profile_picture_src: str | None
+  prefecture: str | None
+  city_ward: str | None
+  postal_code: str | None
+  account_language: str | None
+  english_ok: bool | None
+  japanese_ok: bool | None
+  average_user_rating: float | None
+  user_profile_bio: str | None
+  user_bio_picture_src_list: str | None
+
+  class Config:
+    from_attributes = True


### PR DESCRIPTION
All endpoints that respond with the appuser object no longer include firebase_user_id --> this is not needed by anything as it is sent with the firebase bearer token already

In addition, the responses of the public endpoints /appuser-extended and /appuser-sitter no longer include email or street address --> neither of these fields were intended to be displayed in the search results or on the public sitter profile to begin with

GET /appuser/{id} now requires login (it was previously left public) --> Frontend components using this already send the bearer token in the fetch request, so no change is necessary