### PR TITLE
fix: Adds missing fields to response basemodels for appuser

### DIFF
--- a/pet_sitter/basemodels.py
+++ b/pet_sitter/basemodels.py
@@ -119,6 +119,10 @@ class FullAppuserResponseObject(BaseModel):
   average_user_rating: float | None
   user_profile_bio: str | None
   user_bio_picture_src_list: str | None
+  is_sitter: bool | None
+  account_created: datetime | None
+  last_updated: datetime | None
+  last_login: datetime | None
 
   class Config:
     from_attributes = True
@@ -137,6 +141,10 @@ class ReducedAppuserResponseObject(BaseModel):
   average_user_rating: float | None
   user_profile_bio: str | None
   user_bio_picture_src_list: str | None
+  is_sitter: bool | None
+  account_created: datetime | None
+  last_updated: datetime | None
+  last_login: datetime | None
 
   class Config:
     from_attributes = True


### PR DESCRIPTION
This change fixes the below observed issues:
-Nav menu shows "Become a Sitter" even for users who are sitters (instead of expected "Sitter Profile")
-Nav menu does not show "Requests" for users who are sitters
-"Member Since" on user profile appears blank regardless of actual value
-"Last Updated" on user profile appears blank regardless of actual value
-"Last Active" on sitter profile says "now" regardless of actual value